### PR TITLE
fixed texture index wrong parsing and generated mtl file when materials are used in original obj file

### DIFF
--- a/MeshDecimatorTool/ObjMesh.cs
+++ b/MeshDecimatorTool/ObjMesh.cs
@@ -384,7 +384,7 @@ namespace MeshDecimatorTool
                             {
                                 int splitIndex = word.IndexOf('/');
                                 string word1 = word.Substring(0, splitIndex);
-                                string word2 = word.Substring(splitIndex);
+                                string word2 = word.Substring(splitIndex + 1);
                                 int.TryParse(word1, out vertexIndex);
                                 int.TryParse(word2, out texIndex);
                                 vertexIndex = ShiftIndex(vertexIndex, readVertexList.Count);

--- a/MeshDecimatorTool/Program.cs
+++ b/MeshDecimatorTool/Program.cs
@@ -103,6 +103,8 @@ namespace MeshDecimatorTool
 
                 ObjMesh destObjMesh = new ObjMesh(destVertices, destIndices);
                 destObjMesh.Normals = destNormals;
+                destObjMesh.MaterialLibraries = sourceObjMesh.MaterialLibraries;
+                destObjMesh.SubMeshMaterials = sourceObjMesh.SubMeshMaterials;
 
                 if (sourceTexCoords2D != null)
                 {


### PR DESCRIPTION
When I try out this awesome tool I found that the parse of face infomation of obj file like "f 1/1 1/2 3/3" has a mistake. In the ReadFile method of ObjMesh, line 387, word2 should be word.Substring(splitIndex + 1), the original code will always parse word2 to be 0, and will cause the output uv to always be 0.
Besides, I found that material info (related mtl file and also the usemtl XXX statements) are not generated, I think adding the following codes might solve this problem after mesh decimation and destObjMesh are generated.
`destObjMesh.MaterialLibraries = sourceObjMesh.MaterialLibraries;`
`destObjMesh.SubMeshMaterials = sourceObjMesh.SubMeshMaterials;`